### PR TITLE
ubuntu下编译工程的问题修复

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ from the Google Chromium. That code include:
 ### Linux
 要求: CMake 3.6或更高版本，GCC 7.3或更高版本。  
 1. 需要依赖glib，有些Linux发行版不带glib，需要自行安装，安装之后需要修改CMakeLists.txt中BASE\_INCLUDE\_PLATFORM\_DIRECTORIES这个变量所定义的glib头文件目录。
-2. 进入scm目录，运行build\_base\_linux.sh脚本编译即可。
+2. 需要依赖event，有些Linux发行版不带event，需要自行安装。
+3. 进入scm目录，运行build\_base\_linux.sh脚本编译即可。
 ### macOS
 要求: Xcode 10.1或更高版本  
 1. 需要依赖libevent，推荐使用这个版本:https://chromium.googlesource.com/chromium/+/trunk/third_party/libevent  

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -117,6 +117,7 @@ if(Linux MATCHES ${BASE_BUILD_PLATFORM})
         base/files/file_path_watcher_linux.cc
         base/third_party/nspr/prcpucfg_linux.h
         base/message_pump_libevent.h
+        base/message_pump_libevent.cc
     )
 endif()
 


### PR DESCRIPTION
0、非常感谢作者，我是初学尝试使用chrome base的代码。
1、添加对event依赖的说明。
2、使用base编译sample时，存在符号未定义，找到cmake中的问题，并进行修复。
![Snipaste_2024-04-30_11-11-59](https://github.com/shaoyuan1943/chromium-base/assets/48829659/531063b6-7f20-451c-95bc-3eb5aaddd1fb)
